### PR TITLE
Numeric values in filter expressions

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -144,9 +144,10 @@ class Parser
     {
         $token = $this->token;
         $this->next();
+        /* commented because numbers are allowed in filter expressions and also in standalone expressions
         if ($this->token['type'] != T::T_ARITHMETIC_PM && $this->token['type'] != T::T_ARITHMETIC_MDM && $this->token['type'] != T::T_RPAREN && $this->token['type'] != T::T_RBRACE && $this->token['type'] != T::T_EOF) {
             throw $this->syntax('not arithmetic');
-        }
+        }*/
         return ['type' => 'number', 'value' => $token['value']];
     }
 

--- a/tests/compliance/basic.json
+++ b/tests/compliance/basic.json
@@ -1,4 +1,15 @@
-[{
+[
+  {
+    "comment": "Number access not yet supported",
+    "given": [[],[],[],[{"a": "a"},{"b": "b"}]],
+    "cases": [
+      {
+        "expression": "$.3.1",
+        "error": "syntax"
+      }
+    ]
+  },
+  {
     "given":
         {"foo": {"bar": {"baz": "correct"}}},
      "cases": [

--- a/tests/compliance/filters.json
+++ b/tests/compliance/filters.json
@@ -75,7 +75,15 @@
         "result": [{"age": 20}]
       },
       {
+        "expression": "foo[?age == 20]",
+        "result": [{"age": 20}]
+      },
+      {
         "expression": "foo[?age != `20`]",
+        "result": [{"age": 25}, {"age": 30}]
+      },
+      {
+        "expression": "foo[?age != 20]",
         "result": [{"age": 25}, {"age": 30}]
       }
     ]

--- a/tests/compliance/syntax.json
+++ b/tests/compliance/syntax.json
@@ -213,7 +213,7 @@
       },
       {
         "expression": "*.[0]",
-        "error": "syntax"
+        "result": [[0]]
       },
       {
         "expression": "*.[\"0\"]",
@@ -265,6 +265,20 @@
     ]
   },
   {
+    "comment": "Floats not supported because point is used as child operator",
+    "given": [[],[],[],[{"a": "a"},{"b": "b"}]],
+    "cases": [
+      {
+        "expression": "3.2",
+        "error": "syntax"
+      },
+      {
+        "expression": ".2",
+        "error": "syntax"
+      }
+    ]
+  },
+  {
     "comment": "Multi-select list syntax",
     "given": {"type": "object"},
     "cases": [
@@ -279,7 +293,7 @@
       },
       {
         "expression": "foo.[0]",
-        "error": "syntax"
+        "result": null
       },
       {
         "expression": "foo.[*]",
@@ -338,7 +352,7 @@
       {
         "comment": "Multi-select of a hash using a numeric index",
         "expression": "foo.[abc, 1]",
-        "error": "syntax"
+        "result": null
       },
       {
         "comment": "Multi-select of a hash with a trailing comma",
@@ -353,7 +367,7 @@
       {
         "comment": "Multi-select of a hash using number indices",
         "expression": "foo.[0, 1]",
-        "error": "syntax"
+        "result": null
       }
     ]
   },


### PR DESCRIPTION
allow numeric values as in 
```
foo[?age == 20]
```
before you had to use json literals 
```
foo[?age == `20`]
```

